### PR TITLE
default injection without name reference Ask

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/dsl/context/ModuleDefinition.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/dsl/context/ModuleDefinition.kt
@@ -31,6 +31,7 @@ import org.koin.dsl.definition.Kind
  *
  * @author - Arnaud GIULIANI
  * @author - Laurent Baresse
+ * @author - Eslam Hussein
  *
  * @param path - module path
  * @param createOnStart - module's definition are created on Koin's start
@@ -182,7 +183,7 @@ class ModuleDefinition(
      * @param parameters - injection parameters
      */
     inline fun <reified T : Any> get(
-        name: String = "",
+        name: String = T::class.simpleName?:"default",
         scopeId: String? = null,
         noinline parameters: ParameterDefinition = emptyParameterDefinition()
     ): T {


### PR DESCRIPTION
default injection without name reference 
the default  name was  "" I changed it to be the name of the class to avoid the need to set the reference name by every using  


https://stackoverflow.com/questions/53988902/koin-default-implementation-without-name-reference